### PR TITLE
update file path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A GeoArray is an AbstractArray, an AffineMap for calculating coordinates based o
 
 ## Installation
 ```julia
-(v1.3 pkg> add GeoArrays
+(v1.3) pkg> add GeoArrays
 ```
 
 ## Examples
@@ -15,7 +15,7 @@ A GeoArray is an AbstractArray, an AffineMap for calculating coordinates based o
 julia> using GeoArrays
 
 # Read TIF file
-julia> fn = joinpath(dirname(pathof(GeoArrays)), "..", "test/data/utmsmall.tif")
+julia> fn = download("https://github.com/yeesian/ArchGDALDatasets/blob/master/data/utmsmall.tif?raw=true")
 julia> geoarray = GeoArrays.read(fn)
 100×100×1 GeoArray{UInt8}:
 ...


### PR DESCRIPTION
The file used in the README isn't in the file tree anymore and raises an error. I updated it to use a shortened version of `test/get_testdata.jl`.

Before:
```
julia> fn = joinpath(dirname(pathof(GeoArrays)), "..", "test/data/utmsmall.tif")
"/home/crgxcf/.julia/packages/GeoArrays/IRlVl/src/../test/data/utmsmall.tif"

julia> geoarray = GeoArrays.read(fn)
ERROR: File not found.
Stacktrace:
 [1] error(::String) at ./error.jl:33
 [2] read(::String) at /home/crgxcf/.julia/packages/GeoArrays/IRlVl/src/io.jl:15
 [3] top-level scope at REPL[3]:1
```
After:
```
julia> fn = download("https://github.com/yeesian/ArchGDALDatasets/blob/master/data/utmsmall.tif?raw=true")
"/tmp/jl_XvLLmU"

julia> geoarray = GeoArrays.read(fn)
100×100×1 GeoArray{UInt8}:
0x6b  0x73  0x73  0x94  0x84  0xbd  0xc5  0x94  0x7b  0x8c  …  0x08  0x21  0x10  0x10  0x10  0x21  0x42  0x42  0x84
```