### PR TITLE
RFC: Allow extracting full range of x and y coordinates

### DIFF
--- a/src/geoarray.jl
+++ b/src/geoarray.jl
@@ -73,3 +73,35 @@ function indexmissing(ga::GeoArray)
     (ui, uj) = size(ga)[1:2]
     ci = [[i,j] for i in 1:ui, j in 1:uj if ismissing(ga.A[i, j])]
 end
+
+# Generate coordinates for one dimension of a GeoArray
+function coords(ga::GeoArray, dim::Symbol)
+    if is_rotated(ga)
+        error("This method cannot be used for a rotated GeoArray")
+    end
+    if dim==:x
+        ui = size(ga,1)
+        ci = [coords(ga, SVector{2}(i,1))[1] for i in 1:ui+1]
+    elseif dim==:y
+        uj = size(ga,2)
+        ci = [coords(ga, SVector{2}(1,j))[2] for j in 1:uj+1]
+    else
+        error("Use :x or :y as second argument")
+    end
+    return ci
+end
+function centercoords(ga::GeoArray, dim::Symbol)
+    if is_rotated(ga)
+        error("This method cannot be used for a rotated GeoArray")
+    end
+    if dim==:x
+        ui = size(ga,1)
+        ci = [centercoords(ga, SVector{2}(i,1))[1] for i in 1:ui]
+    elseif dim==:y
+        uj = size(ga,2)
+        ci = [centercoords(ga, SVector{2}(1,j))[2] for j in 1:uj]
+    else
+        error("Use :x or :y as second argument")
+    end
+    return ci
+end

--- a/test/test_geoarray.jl
+++ b/test/test_geoarray.jl
@@ -5,3 +5,14 @@
     @test bboxes(ga)[1] == (min_x=440720.0, max_x=440780.0, min_y=3.75126e6, max_y=3.75132e6)
     @test bboxes(ga)[end] == (min_x=446660.0, max_x=446720.0, min_y=3.74532e6, max_y=3.74538e6)
 end
+
+using CoordinateTransformations
+@testset "coords" begin
+    straight = GeoArray(rand(5, 5, 1), AffineMap([1.0 0.0; 0.0 -1.0], [375000.03, 380000.03]),"")
+    rot = GeoArray(rand(5, 5, 1), AffineMap([1.0 0.5; 0.1 1.0], [0.0, 0.0]),"")
+    @test coords(straight, :x) == collect(375000.03:1:375005.03)
+    @test coords(straight, :y) == collect(380000.03:-1:379995.03)
+    @test_throws ErrorException coords(straight, :z)
+    @test_throws ErrorException coords(rot, :x)
+    @test_throws ErrorException coords(rot, :y)
+end


### PR DESCRIPTION
Would this be useful:
```
julia> coords(ga, :y)
719-element Array{Float64,1}:
 2.826915e6
 2.82661495821727e6
 2.8263149164345404e6
 ⋮
 2.6120850835654596e6
 2.61178504178273e6
 2.611485e6
```
?

TODO: tests