### PR TITLE
[breaking] Less strict in types which we accept and unified indices/coords behaviour.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GeoArrays"
 uuid = "2fb1d81b-e6a0-5fc5-82e6-8e06903437ab"
 authors = ["Maarten Pronk <git@evetion.nl>"]
-version = "0.5.1"
+version = "0.6.0"
 
 [deps]
 ArchGDAL = "c9ce4bd3-c3d5-55b8-8973-c0e20141b8c3"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+GeoArrays = "2fb1d81b-e6a0-5fc5-82e6-8e06903437ab"
 
 [compat]
 Documenter = "~0.23"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,8 +1,198 @@
-# GeoArrays.jl Documentation
+[![](https://img.shields.io/badge/docs-dev-blue.svg)](https://evetion.github.io/GeoArrays.jl/dev) [![](https://img.shields.io/badge/docs-stable-blue.svg)](https://evetion.github.io/GeoArrays.jl/stable) [![CI](https://github.com/evetion/GeoArrays.jl/actions/workflows/CI.yml/badge.svg)](https://github.com/evetion/GeoArrays.jl/actions/workflows/CI.yml) [![codecov](https://codecov.io/gh/evetion/GeoArrays.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/evetion/GeoArrays.jl)
 
-```@contents
+# GeoArrays
+
+Simple geographical raster interaction built on top of [ArchGDAL](https://github.com/yeesian/ArchGDAL.jl/), [GDAL](https://github.com/JuliaGeo/GDAL.jl) and [CoordinateTransformations](https://github.com/FugroRoames/CoordinateTransformations.jl).
+
+A GeoArray is an AbstractArray, an AffineMap for calculating coordinates based on the axes and a CRS definition to interpret these coordinates into in the real world. It's three dimensional and can be seen as a stack (3D) of 2D geospatial rasters (bands), the dimensions are :x, :y, and :bands. The AffineMap and CRS (coordinates) only operate on the :x and :y dimensions.
+
+This packages takes its inspiration from Python's [rasterio](https://github.com/mapbox/rasterio).
+
+## Installation
+
+```julia
+(v1.7) pkg> add GeoArrays
 ```
 
+## Examples
+
+### Basic Usage
+
+Load the `GeoArrays` package.
+
+```julia
+julia> using GeoArrays
+```
+
+Read a GeoTIFF file and display its information, i.e. AffineMap and projection (CRS).
+
+```julia
+# Read TIF file
+julia> fn = download("https://github.com/yeesian/ArchGDALDatasets/blob/master/data/utmsmall.tif?raw=true")
+julia> geoarray = GeoArrays.read(fn)
+100x100x1 Array{UInt8,3} with AffineMap([60.0 0.0; 0.0 -60.0], [440720.0, 3.75132e6]) and CRS PROJCS["NAD27 / UTM zone 11N"...
+
+# Affinemap containing offset and scaling
+julia> geoarray.f
+AffineMap([60.0 0.0; 0.0 -60.0], [440720.0, 3.75132e6])
+
+# WKT projection string
+julia> geoarray.crs
+GeoFormatTypes.WellKnownText{GeoFormatTypes.CRS,String}(GeoFormatTypes.CRS(), "PROJCS[\"NAD27 / UTM zone 11N\",GEOGCS[\"NAD27\",DATUM[\"North_American_Datum_1927\",SPHEROID[\"Clarke 1866\",6378206.4,294.978698213898,AUTHORITY[\"EPSG\",\"7008\"]],AUTHORITY[\"EPSG\",\"6267\"]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4267\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",-117],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"26711\"]]")
+```
+
+### Writing to GeoTIFF
+
+Create a random `GeoArray` and write it to a GeoTIFF file.
+
+```julia
+# Create, reference and write a TIFF
+julia> ga = GeoArray(rand(100,200))
+julia> bbox!(ga, (min_x=2., min_y=51., max_x=5., max_y=54.))  # roughly the Netherlands
+julia> epsg!(ga, 4326)  # in WGS84
+julia> GeoArrays.write!("test.tif", ga)
+```
+
+### Streaming support
+
+The package supports streaming reading.
+
+```julia
+# Read in 39774x60559x1 raster (AHN3), but without masking (missing) support
+julia> @time ga = GeoArrays.read(fn, masked=false)
+  0.001917 seconds (46 allocations: 2.938 KiB)
+39774x60559x1 ArchGDAL.RasterDataset{Float32,ArchGDAL.IDataset} with AffineMap([1.0433425614165472e-6 0.0; 0.0 -1.0433425614165472e-6], [0.8932098305563291, 0.11903776654646055]) and CRS PROJCS["Amersfoort / RD New",GEOGCS["Amersfoort",DATUM["Amersfoort",SPHEROID["Bessel 1841",6377397.155,299.1528128,AUTHORITY["EPSG","7004"]],AUTHORITY["EPSG","6289"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4289"]],PROJECTION["Oblique_Stereographic"],PARAMETER["latitude_of_origin",52.1561605555556],PARAMETER["central_meridian",5.38763888888889],PARAMETER["scale_factor",0.9999079],PARAMETER["false_easting",155000],PARAMETER["false_northing",463000],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH],AUTHORITY["EPSG","28992"]]
+```
+
+### Reading bands
+
+GeoTIFFs can be large, with several bands, one can read. 
+
+When working with large rasters, e.g. with satellite images that can be GB in size, it is useful to be able to read only one band (or a selection of them) to `GeoArray`. When using `read`, one can specify the band.
+
+```julia
+# Get file
+julia> fn = download("https://github.com/yeesian/ArchGDALDatasets/blob/master/pyrasterio/RGB.byte.tif?raw=true")
+
+# Read band 2
+julia> ga_band = GeoArrays.read(fn, masked=false, band=2)
+791x718x1 Array{UInt8, 3} with AffineMap([300.0379266750948 0.0; 0.0 -300.041782729805], [101985.0, 2.826915e6]) and CRS PROJCS["UTM Zone 18, Northern Hemisphere",GEOGCS["Unknown datum based upon the WGS 84 ellipsoid",DATUM["Not_specified_based_on_WGS_84_spheroid",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]]],PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]]],PROJECTION["Transverse_Mercator"],PARAMETER["latitude_of_origin",0],PARAMETER["central_meridian",-75],PARAMETER["scale_factor",0.9996],PARAMETER["false_easting",500000],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH]]
+```
+
+### Using coordinates
+
+`GeoArray` has geographical coordinates for all array elements (pixels). They can be retrieved with the `coords` function.
+
+```julia
+# Find coordinates by index
+julia> coords(geoarray, [1,1])
+2-element StaticArrays.SArray{Tuple{2},Float64,1,2}:
+ 440720.0
+      3.75132e6
+```
+
+All coordinates (tuples) are obtained when omitting the index parameter.
+
+```julia
+# Find all coordinates
+julia> coords(geoarray)
+101×101 Array{StaticArrays.SArray{Tuple{2},Float64,1,2},2}:
+ [440720.0, 3.75132e6]  [440720.0, 3.75126e6]  [440720.0, 3.7512e6] ...
+ ...
+```
+
+The operation can be reversed, i.e. row and column index can be computed from coordinates with the `indices` function.
+
+```julia
+# Find index by coordinates
+julia> indices(geoarray, [440720.0, 3.75132e6])
+2-element StaticArrays.SArray{Tuple{2},Int64,1,2}:
+ 1
+ 1
+```
+### Manipulation
+
+Basic `GeoArray` manipulation is implemented, e.g. translation.
+```julia
+# Translate complete raster by x + 100
+julia> trans = Translation(100, 0)
+julia> compose!(ga, trans)
+```
+
+When GeoArrays have the same dimensions, AffineMap and CRS, addition, subtraction, multiplication and division can be used. 
+
+```julia
+# Math with GeoArrays (- + * /)
+julia> GeoArray(rand(5,5,1)) - GeoArray(rand(5,5,1))
+5x5x1 Array{Float64,3} with AffineMap([1.0 0.0; 0.0 1.0], [0.0, 0.0]) and undefined CRS
+```
+
+### Interpolation
+
+GeoArrays can be interpolated with the `interpolate` function.
+
+```julia
+julia> using GeoEstimation  # or any esimation solver from the GeoStats ecosystem
+julia> ga = GeoArray(Array{Union{Missing, Float64}}(rand(5, 1)))
+julia> ga.A[2,1] = missing
+[:, :, 1] =
+ 0.6760718768442127
+  missing
+ 0.852882193026649
+ 0.7137410453351622
+ 0.5949409082233854
+julia> GeoArrays.interpolate!(ga, IDW(:band => (neighbors=3,)))  # band is the hardcoded variable
+[:, :, 1] =
+ 0.6760718768442127
+ 0.7543298370153771
+ 0.852882193026649
+ 0.7137410453351622
+ 0.5949409082233854
+```
+
+### Plotting
+
+Individual bands from a GeoArray can be plotted with the `plot` function. By default the first band is used.
+
+```julia
+# Plot a GeoArray
+julia> using Plots
+julia> fn = download("https://github.com/yeesian/ArchGDALDatasets/blob/master/pyrasterio/RGB.byte.tif?raw=true")
+julia> ga = GeoArrays.read(fn)
+julia> plot(ga)
+
+# or plot a band other than the first one
+julia> plot(ga, band=2)
+```
+
+![example plot](../img/RGB.byte.png)
+
+### Subsetting arrays
+
+GeoArrays can be subset by row, column and band using the array subsetting notation, e.g. `ga[100:200, 200:300, 1:2]`.
+
+```julia
+# Get file
+julia> fn = download("https://github.com/yeesian/ArchGDALDatasets/blob/master/pyrasterio/RGB.byte.tif?raw=true")
+
+# Read the entire file
+julia> ga = GeoArrays.read(fn);
+
+julia> ga.f
+AffineMap([300.0379266750948 0.0; 0.0 -300.041782729805], [101985.0, 2.826915e6])
+
+julia> ga_sub = ga[200:500,200:400,begin:end]
+301x201x3 Array{Union{Missing, UInt8}, 3} with AffineMap([300.0379266750948 0.0; 0.0 -300.041782729805], [161692.54740834387, 2.767206685236769e6]) and CRS PROJCS["UTM Zone 18, Northern Hemisphere",GEOGCS["Unknown datum based upon the WGS 84 ellipsoid",DATUM["Not_specified_based_on_WGS_84_spheroid",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]]],PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]]],PROJECTION["Transverse_Mercator"],PARAMETER["latitude_of_origin",0],PARAMETER["central_meridian",-75],PARAMETER["scale_factor",0.9996],PARAMETER["false_easting",500000],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH]]
+
+julia> ga_sub.f
+AffineMap([300.0379266750948 0.0; 0.0 -300.041782729805], [161692.54740834387, 2.767206685236769e6])
+
+julia> plot(ga_sub)
+```
+![example plot](../img/RGB.byte.subset.png)
+
+
+## Reference
 ```@autodocs
 Modules = [GeoArrays]
 Order   = [:function, :type]

--- a/src/GeoArrays.jl
+++ b/src/GeoArrays.jl
@@ -18,8 +18,8 @@ include("plot.jl")
 export GeoArray
 
 export coords
-export centercoords
 export indices
+export Vertex, Center
 
 export bbox
 export bbox!

--- a/src/geoarray.jl
+++ b/src/geoarray.jl
@@ -163,7 +163,7 @@ Retrieve coordinates of the cell index by `p`.
 See `indices` for the inverse function.
 """
 function coords(ga::GeoArray, p::SVector{2,<:Integer}, strategy::AbstractStrategy)
-    ga.f(p .- strategy.offset)
+    SVector{2}(ga.f(p .- strategy.offset))
 end
 coords(ga::GeoArray, p::Vector{<:Integer}, strategy::AbstractStrategy=Center()) = coords(ga, SVector{2}(p), strategy)
 coords(ga::GeoArray, p::Tuple{<:Integer,<:Integer}, strategy::AbstractStrategy=Center()) = coords(ga, SVector{2}(p), strategy)
@@ -186,7 +186,7 @@ indices(ga::GeoArray, p::Tuple{<:AbstractFloat,<:AbstractFloat}, strategy::Abstr
 function coords(ga::GeoArray, strategy::AbstractStrategy=Center())
     (ui, uj) = size(ga)[1:2]
     extra = typeof(strategy) == Center ? 0 : 1
-    [coords(ga, SVector{2}(i, j), strategy) for i in 1:ui + extra, j in 1:uj + extra]
+    [coords(ga, SVector{2}(i, j), strategy) for i in 1:ui + extra, j in 1:uj + extra]::Matrix{SVector{2, Float64}}
 end
 
 # Generate coordinates for one dimension of a GeoArray
@@ -206,8 +206,6 @@ function coords(ga::GeoArray, dim::Symbol, strategy::AbstractStrategy=Center())
     end
     return ci
 end
-
-
 
 """
     coords!(ga, x::AbstractUnitRange, y::AbstractUnitRange)

--- a/src/geoarray.jl
+++ b/src/geoarray.jl
@@ -1,22 +1,95 @@
+"""
+    GeoArray{T <: Union{Real,Union{Missing,Real}}} <: AbstractArray{T,3}
+
+A GeoArray is an AbstractArray, an AffineMap for calculating coordinates based on the axes and a CRS definition to interpret these coordinates into in the real world.
+It's three dimensional and can be seen as a stack (3D) of 2D geospatial rasters (bands), the dimensions are :x, :y, and :bands.
+The AffineMap and CRS (coordinates) only operate on the :x and :y dimensions.
+"""
 mutable struct GeoArray{T <: Union{Real,Union{Missing,Real}}} <: AbstractArray{T,3}
     A::AbstractArray{T,3}
     f::AffineMap
     crs::WellKnownText{GeoFormatTypes.CRS,<:String}
 end
+
+"""
+    GeoArray(A::AbstractArray{T,3} where T <: Union{Real,Union{Missing,Real}})
+
+Construct a GeoArray from any Array. A default `AffineMap` and `CRS` will be generated.
+
+# Examples
+```julia-repl
+julia> GeoArray(rand(10,10,1))
+10x10x1 Array{Float64, 3} with AffineMap([1.0 0.0; 0.0 1.0], [0.0, 0.0]) and undefined CRS
+```
+"""
 GeoArray(A::AbstractArray{T,3} where T <: Union{Real,Union{Missing,Real}}) = GeoArray(A, geotransform_to_affine(SVector(0., 1., 0., 0., 0., 1.)), "")
+"""
+    GeoArray(A::AbstractArray{T,3} where T <: Union{Real,Union{Missing,Real}}, f::AffineMap)
+
+Construct a GeoArray from any Array and an `AffineMap` that specifies the coordinates. A default `CRS` will be generated.
+"""
 GeoArray(A::AbstractArray{T,3} where T <: Union{Real,Union{Missing,Real}}, f::AffineMap) = GeoArray(A, f, GFT.WellKnownText(GFT.CRS(), ""))
+
+"""
+    GeoArray(A::AbstractArray{T,3} where T <: Union{Real,Union{Missing,Real}}, f::AffineMap, crs::String)
+
+Construct a GeoArray from any Array and an `AffineMap` that specifies the coordinates and `crs` string in WKT format.
+"""
 GeoArray(A::AbstractArray{T,3} where T <: Union{Real,Union{Missing,Real}}, f::AffineMap, crs::String) = GeoArray(A, f, GFT.WellKnownText(GFT.CRS(), crs))
+
+"""
+    GeoArray(A::AbstractArray{T,2} where T <: Union{Real,Union{Missing,Real}})
+
+Construct a GeoArray from any Matrix, a third singleton dimension will be added automatically.
+
+# Examples
+```julia-repl
+julia> GeoArray(rand(10,10))
+10x10x1 Array{Float64, 3} with AffineMap([1.0 0.0; 0.0 1.0], [0.0, 0.0]) and undefined CRS
+```
+"""
 GeoArray(A::AbstractArray{T,2} where T <: Union{Real,Union{Missing,Real}}, args...) = GeoArray(reshape(A, size(A)..., 1), args...)
+
+"""
+    GeoArray(A::AbstractArray{T,3} where T <: Union{Real,Union{Missing,Real}}, x::AbstractRange, y::AbstractRange, args...)
+
+Construct a GeoArray any Array and it's coordinates from `AbstractRange`s for each dimension.
+"""
 function GeoArray(A::AbstractArray{T,3} where T <: Union{Real,Union{Missing,Real}}, x::AbstractRange, y::AbstractRange, args...)
     size(A)[1:2] != (length(x), length(y)) && error("Size of `GeoArray` $(size(A)) does not match size of (x,y): $((length(x), length(y))). Note that this function takes *center coordinates*.")
     f = unitrange_to_affine(x, y)
     GeoArray(A, f, args...)
 end
 
+# Behave like an Array
 Base.size(ga::GeoArray) = size(ga.A)
 Base.IndexStyle(::Type{T}) where {T <: GeoArray} = IndexCartesian()
+Base.similar(ga::GeoArray, t::Type) = GeoArray(similar(ga.A, t), ga.f, ga.crs)
+Base.iterate(ga::GeoArray) = iterate(ga.A)
+Base.length(ga::GeoArray) = length(ga.A)
+Base.parent(ga::GeoArray) = ga.A
+Base.eltype(::Type{GeoArray{T}}) where {T} = T
+Base.show(io::IO, ::MIME"text/plain", ga::GeoArray) = show(io, ga)
 
-function Base.getindex(ga::GeoArray, i::AbstractRange, j::AbstractRange, k::Union{Colon,AbstractRange,Int})
+function Base.show(io::IO, ga::GeoArray)
+    crs = GeoFormatTypes.val(ga.crs)
+    wkt = length(crs) == 0 ? "undefined CRS" : "CRS $crs"
+    print(io, "$(join(size(ga), "x")) $(typeof(ga.A)) with $(ga.f) and $(wkt)")
+end
+
+# Getindex
+"""
+    getindex(ga::GeoArray, i::AbstractRange, j::AbstractRange, k::Union{Colon,AbstractRange,Integer})
+
+Index a GeoArray with `AbstractRange`s to get a cropped GeoArray with the correct `AffineMap` set.
+
+# Examples
+```julia-repl
+julia> ga[2:3,2:3,1]
+2x2x1 Array{Float64, 3} with AffineMap([1.0 0.0; 0.0 1.0], [1.0, 1.0]) and undefined CRS
+```
+"""
+function Base.getindex(ga::GeoArray, i::AbstractRange, j::AbstractRange, k::Union{Colon,AbstractRange,Integer})
     A = getindex(ga.A, i, j, k)
     x, y = first(i) - 1, first(j) - 1
     t = ga.f(SVector(x, y))
@@ -29,103 +102,105 @@ function Base.getindex(ga::GeoArray, i::AbstractRange, j::AbstractRange)
     GeoArray(A, AffineMap(ga.f.linear, t), ga.crs)
 end
 
-Base.getindex(ga::GeoArray, I::Vararg{Int,2}) = getindex(ga.A, I..., :)
-Base.getindex(ga::GeoArray, I::Vararg{Int,3}) = getindex(ga.A, I...)
+Base.getindex(ga::GeoArray, I::Vararg{<:Integer,2}) = getindex(ga.A, I..., :)
+Base.getindex(ga::GeoArray, I::Vararg{<:Integer,3}) = getindex(ga.A, I...)
 
-Base.similar(ga::GeoArray, t::Type) = GeoArray(similar(ga.A, t), ga.f, ga.crs)
+# Getindex and setindex! with floats
+"""
+    getindex(ga::GeoArray, I::SVector{2,<:AbstractFloat})
 
-Base.setindex!(ga::GeoArray, v, I::Vararg{Union{Int,<:AbstractRange{<:Int}},2}) = setindex!(ga.A, v, I..., :)
-Base.setindex!(ga::GeoArray, v, I::Vararg{Union{Int,<:AbstractRange{<:Int}},3} ) = setindex!(ga.A, v, I...)
+Index a GeoArray with `AbstractFloat`s to automatically get the value at that coordinate, using the function `indices`.
+A `BoundsError` is raised if the coordinate falls outside the bounds of the raster.
 
-Base.iterate(ga::GeoArray) = iterate(ga.A)
-Base.length(ga::GeoArray) = length(ga.A)
-Base.parent(ga::GeoArray) = ga.A
-# Base.map(f, ga::GeoArray) = GeoArray(map(f, ga.A), ga.f, ga.crs)
-# Base.convert(::Type{Array{T, 3}}, A::GeoArray{T}) where {T} = convert(Array{T,3}, ga.A)
-Base.eltype(::Type{GeoArray{T}}) where {T} = T
+# Examples
+```julia-repl
+julia> ga[3.0,3.0]
+1-element Vector{Float64}:
+ 0.5630767850028582
+```
+"""
+function Base.getindex(ga::GeoArray, I::SVector{2,<:AbstractFloat})
+    (i, j) = indices(ga, I, Center())
+    ga[i, j, :]
+end
+Base.getindex(ga::GeoArray, I::Vararg{<:AbstractFloat,2}) = getindex(ga, SVector{2}(I))
 
-Base.show(io::IO, ::MIME"text/plain", ga::GeoArray) = show(io, ga)
-function Base.show(io::IO, ga::GeoArray)
-    crs = GeoFormatTypes.val(ga.crs)
-    wkt = length(crs) == 0 ? "undefined CRS" : "CRS $crs"
-    print(io, "$(join(size(ga), "x")) $(typeof(ga.A)) with $(ga.f) and $(wkt)")
+function Base.setindex!(ga::GeoArray, v, I::SVector{2,AbstractFloat})
+    i, j = indices(ga, I, Center())
+    ga.A[i, j, :] .= v
+end
+Base.setindex!(ga::GeoArray, v, I::Vararg{<:AbstractFloat,2}) = setindex!(ga, v, SVector{2}(I))
+Base.setindex!(ga::GeoArray, v, I::Vararg{Union{<:Integer,<:AbstractRange{<:Integer}},2}) = setindex!(ga.A, v, I..., :)
+Base.setindex!(ga::GeoArray, v, I::Vararg{Union{<:Integer,<:AbstractRange{<:Integer}},3} ) = setindex!(ga.A, v, I...)
+
+# Coordinates and indices
+abstract type AbstractStrategy end
+"""
+    Center()
+
+Strategy to use in functions like `indices` and `coords`, in which
+it will use the center of the raster cells to do coordinate conversion.
+"""
+struct Center <: AbstractStrategy
+    offset::Float64
+    Center() = new(0.5)
+end
+"""
+    Vertex()
+
+Strategy to use in functions like `indices` and `coords`, in which
+it will use the top left vertex of the raster cells to do coordinate conversion.
+"""
+struct Vertex <: AbstractStrategy
+    offset::Float64
+    Vertex() = new(1.0)
 end
 
-# Generate upper left coordinates for specic index
-function coords(ga::GeoArray, p::SVector{2,Int})
-    ga.f(p .- 1)
-end
-coords(ga::GeoArray, p::Vector{Int}) = coords(ga, SVector{2}(p))
+"""
+    coords(ga::GeoArray, p::SVector{2,<:Integer}, strategy::AbstractStrategy)
 
-# Generate center coordinates for specific index
-function centercoords(ga::GeoArray, p::SVector{2,Int})
-    ga.f(p .- 0.5)
+Retrieve coordinates of the cell index by `p`.
+See `indices` for the inverse function.
+"""
+function coords(ga::GeoArray, p::SVector{2,<:Integer}, strategy::AbstractStrategy)
+    ga.f(p .- strategy.offset)
 end
-centercoords(ga::GeoArray, p::Vector{Int}) = centercoords(ga, SVector{2}(p))
+coords(ga::GeoArray, p::Vector{<:Integer}, strategy::AbstractStrategy=Center()) = coords(ga, SVector{2}(p), strategy)
+coords(ga::GeoArray, p::Tuple{<:Integer,<:Integer}, strategy::AbstractStrategy=Center()) = coords(ga, SVector{2}(p), strategy)
 
-# Convert coordinates back to indices
-function indices(ga::GeoArray, p::SVector{2,Float64})
-    map(x -> round(Int, x), inv(ga.f)(p)::SVector{2,Float64}) .+ 1
-end
-indices(ga::GeoArray, p::Vector{Float64}) = indices(ga, SVector{2}(p))
-indices(ga::GeoArray, p::Tuple{Float64,Float64}) = indices(ga, SVector{2}(p))
+"""
+    indices(ga::GeoArray, p::SVector{2,<:AbstractFloat}, strategy::AbstractStrategy)
 
-# Overload indexing directly into GeoArray
-# TODO This could be used for interpolation instead
-function Base.getindex(ga::GeoArray, I::SVector{2,Float64})
-    (i, j) = indices(ga, I)
-    return ga[i, j, :]
+Retrieve logical indices of the cell represented by coordinates `p`.
+`strategy` can be used to define whether the coordinates represent the center (`Center`) or the top left corner (`Vertex`) of the cell.
+See `coords` for the inverse function.
+"""
+function indices(ga::GeoArray, p::SVector{2,<:AbstractFloat}, strategy::AbstractStrategy)
+    round.(Int, inv(ga.f)(p) .+ strategy.offset)::SVector{2,Int}
 end
-Base.getindex(ga::GeoArray, I::Vararg{Float64,2}) = Base.getindex(ga, SVector{2}(I))
+indices(ga::GeoArray, p::Vector{<:AbstractFloat}, strategy::AbstractStrategy=Center()) = indices(ga, SVector{2}(p), strategy)
+indices(ga::GeoArray, p::Tuple{<:AbstractFloat,<:AbstractFloat}, strategy::AbstractStrategy=Center()) = indices(ga, SVector{2}(p), strategy)
+
 
 # Generate coordinates for complete GeoArray
-function coords(ga::GeoArray)
+function coords(ga::GeoArray, strategy::AbstractStrategy=Center())
     (ui, uj) = size(ga)[1:2]
-    ci = [coords(ga, SVector{2}(i, j)) for i in 1:ui + 1, j in 1:uj + 1]
-end
-function centercoords(ga::GeoArray)
-    (ui, uj) = size(ga)[1:2]
-    ci = [centercoords(ga, SVector{2}(i, j)) for i in 1:ui, j in 1:uj]
-end
-function centercoordsnotmissing(ga::GeoArray)
-    (ui, uj) = size(ga)[1:2]
-    ci = [centercoords(ga, SVector{2}(i, j)) for i in 1:ui, j in 1:uj if ~ismissing(ga.A[i, j])]
-end
-function centercoordsmissing(ga::GeoArray)
-    (ui, uj) = size(ga)[1:2]
-    ci = [centercoords(ga, SVector{2}(i, j)) for i in 1:ui, j in 1:uj if ismissing(ga.A[i, j])]
-end
-function indexmissing(ga::GeoArray)
-    (ui, uj) = size(ga)[1:2]
-    ci = [[i,j] for i in 1:ui, j in 1:uj if ismissing(ga.A[i, j])]
+    extra = typeof(strategy) == Center ? 0 : 1
+    [coords(ga, SVector{2}(i, j), strategy) for i in 1:ui + extra, j in 1:uj + extra]
 end
 
 # Generate coordinates for one dimension of a GeoArray
-function coords(ga::GeoArray, dim::Symbol)
+function coords(ga::GeoArray, dim::Symbol, strategy::AbstractStrategy=Center())
     if is_rotated(ga)
         error("This method cannot be used for a rotated GeoArray")
     end
+    extra = typeof(strategy) == Center ? 0 : 1
     if dim == :x
         ui = size(ga, 1)
-        ci = [coords(ga, SVector{2}(i, 1))[1] for i in 1:ui + 1]
+        ci = [coords(ga, SVector{2}(i, 1), strategy)[1] for i in 1:ui + extra]
     elseif dim == :y
         uj = size(ga, 2)
-        ci = [coords(ga, SVector{2}(1, j))[2] for j in 1:uj + 1]
-    else
-        error("Use :x or :y as second argument")
-    end
-    return ci
-end
-function centercoords(ga::GeoArray, dim::Symbol)
-    if is_rotated(ga)
-        error("This method cannot be used for a rotated GeoArray")
-    end
-    if dim == :x
-        ui = size(ga, 1)
-        ci = [centercoords(ga, SVector{2}(i, 1))[1] for i in 1:ui]
-    elseif dim == :y
-        uj = size(ga, 2)
-        ci = [centercoords(ga, SVector{2}(1, j))[2] for j in 1:uj]
+        ci = [coords(ga, SVector{2}(1, j), strategy)[2] for j in 1:uj + extra]
     else
         error("Use :x or :y as second argument")
     end
@@ -133,8 +208,13 @@ function centercoords(ga::GeoArray, dim::Symbol)
 end
 
 
-"""Set AffineMap of `GeoArray` by specifying the *center coordinates* for each x, y dimension by a `UnitRange`."""
-function centercoords!(ga, x::AbstractUnitRange, y::AbstractUnitRange)
+
+"""
+    coords!(ga, x::AbstractUnitRange, y::AbstractUnitRange)
+
+Set AffineMap of `GeoArray` by specifying the *center coordinates* for each `x`, `y` dimension by a `UnitRange`.
+"""
+function coords!(ga, x::AbstractUnitRange, y::AbstractUnitRange)
     size(ga)[1:2] != (length(x), length(y)) && error("Size of `GeoArray` $(size(ga)) does not match size of (x,y): $((length(x), length(y))). Note that this function takes *center coordinates*.")
     ga.f = unitrange_to_affine(x, y)
     ga

--- a/src/geoutils.jl
+++ b/src/geoutils.jl
@@ -66,7 +66,7 @@ end
 
 """Generate bounding boxes for GeoArray cells."""
 function bboxes(ga::GeoArray)
-    c = coords(ga)::Array{StaticArrays.SArray{Tuple{2},Float64,1,2},2}
+    c = coords(ga, Vertex())::Array{StaticArrays.SArray{Tuple{2},Float64,1,2},2}
     m, n = size(c)
     cellbounds = Matrix{NamedTuple}(undef, (m-1, n-1))
     for j = 1:n-1, i = 1:m-1

--- a/src/geoutils.jl
+++ b/src/geoutils.jl
@@ -2,32 +2,27 @@ function get_affine_map(ds::ArchGDAL.IDataset)
     # ArchGDAL fails hard on datasets without
     # an affinemap. GDAL documents that on fail
     # a default affinemap should be returned.
+    local gt
     try
-        global gt = ArchGDAL.getgeotransform(ds)
+        gt = ArchGDAL.getgeotransform(ds)
     catch y
         @warn y.msg
-        global gt = [0.,1.,0.,0.,0.,1.]
+        gt = [0.,1.,0.,0.,0.,1.]
     end
-    geotransform_to_affine(SVector{6, Float64}(gt))
+    geotransform_to_affine(gt)
 end
 
-function geotransform_to_affine(gt::SVector{6, Float64})
+function geotransform_to_affine(gt::SVector{6,<:AbstractFloat})
     # See https://lists.osgeo.org/pipermail/gdal-dev/2011-July/029449.html
     # for an explanation of the geotransform format
     AffineMap(SMatrix{2,2}([gt[2] gt[3]; gt[5] gt[6]]), SVector{2}([gt[1], gt[4]]))
 end
-geotransform_to_affine(A::Vector{Float64}) = geotransform_to_affine(SVector{6}(A))
+geotransform_to_affine(A::Vector{<:AbstractFloat}) = geotransform_to_affine(SVector{6}(A))
 
-function affine_to_geotransform(am::AffineMap{SArray{Tuple{2,2},Float64,2,4},SArray{Tuple{2},Float64,1,2}})
+function affine_to_geotransform(am::AffineMap)
     l = am.linear
     t = am.translation
-    [t[1], l[1], l[3], t[2], l[2], l[4]]
-end
-
-function affine_to_geotransform(am::AffineMap{Array{Float64,2},Array{Float64,1}})
-    l = am.linear
-    t = am.translation
-    (length(l) != 4 || length(t) != 2) || error("AffineMap has wrong dimensions.")
+    (length(l) == 4 && length(t) == 2) || error("AffineMap has wrong dimensions.")
     [t[1], l[1], l[3], t[2], l[2], l[4]]
 end
 
@@ -37,43 +32,43 @@ function is_rotated(ga::GeoArray)
 end
 
 function bbox(ga::GeoArray)
-    ax, ay = ga.f(SVector(0,0))
+    ax, ay = ga.f(SVector(0, 0))
     bx, by = ga.f(SVector(size(ga)[1:2]))
-    (min_x=min(ax, bx), min_y=min(ay, by), max_x=max(ax, bx), max_y=max(ay, by))
+    (min_x = min(ax, bx), min_y = min(ay, by), max_x = max(ax, bx), max_y = max(ay, by))
 end
 
 function unitrange_to_affine(x::StepRangeLen, y::StepRangeLen)
-    δx, δy = step(x), step(y)
+    δx, δy = float(step(x)), float(step(y))
     AffineMap(
-        SMatrix{2,2}(δx, 0, 0, δy),
-        SVector(x[1] - δx/2, y[1] - δy/2)
+        SMatrix{2,2}(δx, 0., 0., δy),
+        SVector(x[1] - δx / 2, y[1] - δy / 2)
     )
 end
 
-function bbox_to_affine(size::Tuple{Integer, Integer}, bbox::NamedTuple{(:min_x, :min_y, :max_x, :max_y),Tuple{Float64, Float64, Float64, Float64}})
+function bbox_to_affine(size::Tuple{Integer,Integer}, bbox::NamedTuple{(:min_x, :min_y, :max_x, :max_y)})
     AffineMap(
-        SMatrix{2,2}((bbox.max_x - bbox.min_x) / size[1], 0, 0, (bbox.max_y - bbox.min_y)/size[2]),
-        SVector(bbox.min_x, bbox.min_y)
+        SMatrix{2,2}(float(bbox.max_x - bbox.min_x) / size[1], 0, 0, float(bbox.max_y - bbox.min_y) / size[2]),
+        SVector(float(bbox.min_x), float(bbox.min_y))
         )
 end
 
 """Set geotransform of `GeoArray` by specifying a bounding box.
 Note that this only can result in a non-rotated or skewed `GeoArray`."""
-function bbox!(ga::GeoArray, bbox::NamedTuple{(:min_x, :min_y, :max_x, :max_y),Tuple{Float64, Float64, Float64, Float64}})
+function bbox!(ga::GeoArray, bbox::NamedTuple{(:min_x, :min_y, :max_x, :max_y)})
     ga.f = bbox_to_affine(size(ga)[1:2], bbox)
     ga
 end
 
 """Generate bounding boxes for GeoArray cells."""
 function bboxes(ga::GeoArray)
-    c = coords(ga, Vertex())::Array{StaticArrays.SArray{Tuple{2},Float64,1,2},2}
+    c = coords(ga, Vertex())
     m, n = size(c)
-    cellbounds = Matrix{NamedTuple}(undef, (m-1, n-1))
-    for j = 1:n-1, i = 1:m-1
-        v = c[i:i+1, j:j+1]
-        minx, maxx = extrema(first.(v))::Tuple{Float64, Float64}
-        miny, maxy = extrema(last.(v))::Tuple{Float64, Float64}
-        cellbounds[i, j] = (min_x=minx, max_x=maxx, min_y=miny, max_y=maxy)
+    cellbounds = Matrix{NamedTuple}(undef, (m - 1, n - 1))
+    for j in 1:n - 1, i in 1:m - 1
+        v = c[i:i + 1, j:j + 1]
+        minx, maxx = extrema(first.(v))
+        miny, maxy = extrema(last.(v))
+        cellbounds[i, j] = (min_x = minx, max_x = maxx, min_y = miny, max_y = maxy)
     end
     cellbounds
 end

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -7,9 +7,9 @@ using RecipesBase
     seriestype := :heatmap
     color := :viridis
 
-    coords = centercoords(ga)
-    x = map(x->x[1], coords[:, 1])
-    y = map(x->x[2], coords[end, :])
+    coords = coords(ga, Vertex())
+    x = map(x -> x[1], coords[:, 1])
+    y = map(x -> x[2], coords[end, :])
     z = ga.A[:,:,band]'
 
     # Can't use x/yflip as x/y coords

--- a/test/test_geoarray.jl
+++ b/test/test_geoarray.jl
@@ -14,11 +14,11 @@ end
     @test bboxes(ga)[end] == (min_x = 446660.0, max_x = 446720.0, min_y = 3.74532e6, max_y = 3.74538e6)
 end
 
-@testset "coords" begin
+@testset "Coords" begin
     straight = GeoArray(rand(5, 5, 1), AffineMap([1.0 0.0; 0.0 -1.0], [375000.03, 380000.03]), "")
     rot = GeoArray(rand(5, 5, 1), AffineMap([1.0 0.5; 0.1 1.0], [0.0, 0.0]), "")
-    @test coords(straight, :x) == collect(375000.03:1:375005.03)
-    @test coords(straight, :y) == collect(380000.03:-1:379995.03)
+    @test coords(straight, :x, GeoArrays.Vertex()) == collect(375000.03:1:375005.03)
+    @test coords(straight, :y, GeoArrays.Vertex()) == collect(380000.03:-1:379995.03)
     @test_throws ErrorException coords(straight, :z)
     @test_throws ErrorException coords(rot, :x)
     @test_throws ErrorException coords(rot, :y)
@@ -31,15 +31,15 @@ end
     ga3 = GeoArray(rand(10, 9, 8), x, y)
     ga3 = GeoArray(rand(10, 9, 8), x, y, "")
     for i in 1:length(x), j in 1:length(y)
-        @test GeoArrays.centercoords(ga2, [i,j]) ≈ [x[i],y[j]]
+        @test GeoArrays.coords(ga2, [i,j]) ≈ [x[i],y[j]]
     end
     for i in 1:length(x), j in 1:length(y)
-        @test GeoArrays.centercoords(ga3, [i,j]) ≈ [x[i],y[j]]
+        @test GeoArrays.coords(ga3, [i,j]) ≈ [x[i],y[j]]
     end
     x, y = range(4, stop=8.0, length=11), range(0, stop=1, length=9)
     @test_throws ErrorException GeoArray(rand(10, 9), x, y)
 end
-
+        
 @testset "Conversions" begin
     ga = GeoArray(rand(1:32000, 5, 5))
     GeoArrays.write!(joinpath(testdatadir, "test_conversion.tif"), ga)
@@ -54,4 +54,14 @@ end
     @test gg[1,1] == ga[250,250]
     @test coords(gg, [1, 1]) == coords(ga, [250, 250])
     GeoArrays.write!("test.tif", gg)
+end
+
+@testset "Indexing" begin
+    ga = GeoArray(rand(10, 10))
+    ga[Float32(1.0), Float32(2.0)]
+    i, j = 2, 5
+    x, y = coords(ga, (i, j))
+    ii, jj = indices(ga, (x, y))
+    @test ii == i
+    @test jj == j
 end


### PR DESCRIPTION
Refactored `indices` and `coords` behaviour. Removed `centercoords` variants, replaced them with `strategy` argument in relevant methods.
Default behaviour is now to use `Center` everywhere.

Improved online documentation by docstrings and added README to it.

Fixes #77 