### PR TITLE
Renamed coord variable to c to enable plotting

### DIFF
--- a/src/plot.jl
+++ b/src/plot.jl
@@ -7,9 +7,9 @@ using RecipesBase
     seriestype := :heatmap
     color := :viridis
 
-    coords = coords(ga, Vertex())
-    x = map(x -> x[1], coords[:, 1])
-    y = map(x -> x[2], coords[end, :])
+    c = coords(ga, Vertex())
+    x = map(x -> x[1], c[:, 1])
+    y = map(x -> x[2], c[end, :])
     z = ga.A[:,:,band]'
 
     # Can't use x/yflip as x/y coords


### PR DESCRIPTION
There was a local variable named the same as an export ('coords') in plot.jl that prevented plotting of GeoArrays. Renamed