### PR TITLE
Add linear transformation correction 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GeoArrays"
 uuid = "2fb1d81b-e6a0-5fc5-82e6-8e06903437ab"
 authors = ["Maarten Pronk <git@evetion.nl>"]
-version = "0.7.3"
+version = "0.7.4"
 
 [deps]
 ArchGDAL = "c9ce4bd3-c3d5-55b8-8973-c0e20141b8c3"

--- a/test/test_geoarray.jl
+++ b/test/test_geoarray.jl
@@ -6,6 +6,11 @@ using CoordinateTransformations
     @test length(x[1, 2]) == 5
     @test size(x[1:3, 1:3]) == (3, 3, 5)
     @test size(x[1:3, 1:3, 1:3]) == (3, 3, 3)
+
+    x = GeoArray(rand(10, 10, 2))
+    xs = x[1:2:end, 1:2:end]
+    @test size(xs) == (5, 5, 2)
+    @test bbox(xs) == bbox(x)
 end
 
 @testset "Concrete" begin
@@ -18,9 +23,9 @@ end
 
 @testset "Reading rasters" begin
     ga = GeoArrays.read(joinpath(testdatadir, "data/utmsmall.tif"))
-    @test bbox(ga) == (min_x = 440720.0, min_y = 3.74532e6, max_x = 446720.0, max_y = 3.75132e6)
-    @test bboxes(ga)[1] == (min_x = 440720.0, max_x = 440780.0, min_y = 3.75126e6, max_y = 3.75132e6)
-    @test bboxes(ga)[end] == (min_x = 446660.0, max_x = 446720.0, min_y = 3.74532e6, max_y = 3.74538e6)
+    @test bbox(ga) == (min_x=440720.0, min_y=3.74532e6, max_x=446720.0, max_y=3.75132e6)
+    @test bboxes(ga)[1] == (min_x=440720.0, max_x=440780.0, min_y=3.75126e6, max_y=3.75132e6)
+    @test bboxes(ga)[end] == (min_x=446660.0, max_x=446720.0, min_y=3.74532e6, max_y=3.74538e6)
 end
 
 @testset "Coords" begin
@@ -34,7 +39,7 @@ end
 end
 
 @testset "GeoArray constructors" begin
-    x, y = range(4, stop = 8.0, length = 10), range(0, stop = 1, length = 9)
+    x, y = range(4, stop=8.0, length=10), range(0, stop=1, length=9)
     ga2 = GeoArray(rand(10, 9), x, y)
     ga2 = GeoArray(rand(10, 9), x, y, "")
     ga3 = GeoArray(rand(10, 9, 8), x, y)
@@ -45,7 +50,7 @@ end
     for i in 1:length(x), j in 1:length(y)
         @test GeoArrays.coords(ga3, [i, j]) ≈ [x[i], y[j]]
     end
-    x, y = range(4, stop = 8.0, length = 11), range(0, stop = 1, length = 9)
+    x, y = range(4, stop=8.0, length=11), range(0, stop=1, length=9)
     @test_throws ErrorException GeoArray(rand(10, 9), x, y)
 end
 


### PR DESCRIPTION
when using getindex with a range with a stepsize other than 1. Fixes #96 