### PR TITLE
Subsample geoarrays before plotting, based on plotsize.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ docs/build
 test/*
 !test/*.jl
 Manifest.toml
+docs/src/CHANGELOG.md
+*.tif

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [unreleased]
+
+### Added
+
+- Subsample GeoArrays in plotting for performance. Use `scalefactor` to control this.
+
+### Changed
+
+- Changed `GeoArray` eltype to allow for Complex numbers.
+
+### Fixed
+
+- Profile tool works also for reversed lines
+
+
+## [0.7.9] - 2022-10-15
+
+### Added
+
+- Added `coalesce` option for a GeoArray
+- Added pre:and:post fixes to filenames, now supports netcdf and s3 like paths
+
+### Fixed
+
+- Fixed iterate specification so `sum` on a GeoArray is correct
+
+[unreleased]: https://github.com/evetion/GeoArrays.jl/compare/v0.7.9...HEAD
+[0.7.9]: https://github.com/evetion/GeoArrays.jl/compare/v1.0.0...v0.7.9

--- a/README.md
+++ b/README.md
@@ -163,6 +163,10 @@ julia> plot(ga, band=2)
 
 ![example plot](docs/img/RGB.byte.png)
 
+Note that for larger GeoArrays, only a sample of the data is plotted for performance.
+By default the sample size is twice figure size. You can control this factor by calling `plot(ga, scalefactor=2)`,
+where higher scalefactor yields higher sizes, up to the original GeoArray size.
+
 ### Subsetting arrays
 GeoArrays can be subset by row, column and band using the array subsetting notation, e.g. `ga[100:200, 200:300, 1:2]`.
 
@@ -187,4 +191,4 @@ julia> plot(ga_sub)
 ![example plot](docs/img/RGB.byte.subset.png)
 
 ### Profile
-You can sample the values along a line in a GeoArray with `profile(ga, linestring)`. The linestring can be any geometry that supports [GeoInterface.jl][https://github.com/JuliaGeo/GeoInterface.jl/].
+You can sample the values along a line in a GeoArray with `profile(ga, linestring)`. The linestring can be any geometry that supports [GeoInterface.jl](https://github.com/JuliaGeo/GeoInterface.jl/).

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,6 +1,3 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 GeoArrays = "2fb1d81b-e6a0-5fc5-82e6-8e06903437ab"
-
-[compat]
-Documenter = "~0.23"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,8 +1,25 @@
-push!(LOAD_PATH,"../src/")
+push!(LOAD_PATH, "../src/")
 using Documenter, GeoArrays
 
-makedocs(sitename="GeoArrays.jl")
+cl = joinpath(@__DIR__, "src/CHANGELOG.md")
+isfile(cl) || cp(joinpath(@__DIR__, "../CHANGELOG.md"), cl)
+
+makedocs(
+    modules=[GeoArrays],
+    authors="Maarten Pronk <git@evetion.nl> and contributors",
+    repo="https://github.com/evetion/GeoArrays.jl/blob/{commit}{path}#L{line}",
+    sitename="GeoArrays.jl",
+    format=Documenter.HTML(;
+        prettyurls=get(ENV, "CI", "false") == "true",
+        canonical="https://evetion.github.io/GeoArrays.jl",
+        assets=String[]
+    ),
+    pages=[
+        "Home" => "index.md",
+        "Changelog" => "CHANGELOG.md",
+    ]
+)
 
 deploydocs(
-    repo = "github.com/evetion/GeoArrays.jl.git",
+    repo="github.com/evetion/GeoArrays.jl",
 )

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -172,6 +172,10 @@ julia> plot(ga, band=2)
 
 ![example plot](../img/RGB.byte.png)
 
+Note that for larger GeoArrays, only a sample of the data is plotted for performance.
+By default the sample size is twice figure size. You can control this factor by calling `plot(ga, scalefactor=2)`,
+where higher scalefactor yields higher sizes, up to the original GeoArray size.
+
 ### Subsetting arrays
 
 GeoArrays can be subset by row, column and band using the array subsetting notation, e.g. `ga[100:200, 200:300, 1:2]`.
@@ -197,7 +201,7 @@ julia> plot(ga_sub)
 ![example plot](../img/RGB.byte.subset.png)
 
 ### Profile
-You can sample the values along a line in a GeoArray with `profile(ga, linestring)`. The linestring can be any geometry that supports [GeoInterface.jl][https://github.com/JuliaGeo/GeoInterface.jl/].
+You can sample the values along a line in a GeoArray with `profile(ga, linestring)`. The linestring can be any geometry that supports [GeoInterface.jl](https://github.com/JuliaGeo/GeoInterface.jl/).
 
 ## Reference
 ```@autodocs

--- a/src/geoarray.jl
+++ b/src/geoarray.jl
@@ -1,4 +1,4 @@
-const RealOrMissing = Union{Real,Union{Missing,Real}}
+const RealOrMissing = Union{Number,Union{Missing,Number}}
 
 """
     GeoArray{T::RealOrMissing,A<:AbstractArray{T,3}} <: AbstractArray{T,3}

--- a/src/geoarray.jl
+++ b/src/geoarray.jl
@@ -1,20 +1,20 @@
-const RealOrMissing = Union{Number,Union{Missing,Number}}
+const NumberOrMissing = Union{Number,Union{Missing,Number}}
 
 """
-    GeoArray{T::RealOrMissing,A<:AbstractArray{T,3}} <: AbstractArray{T,3}
+    GeoArray{T::NumberOrMissing,A<:AbstractArray{T,3}} <: AbstractArray{T,3}
 
 A GeoArray is an AbstractArray, an AffineMap for calculating coordinates based on the axes and a CRS definition to interpret these coordinates into in the real world.
 It's three dimensional and can be seen as a stack (3D) of 2D geospatial rasters (bands), the dimensions are :x, :y, and :bands.
 The AffineMap and CRS (coordinates) only operate on the :x and :y dimensions.
 """
-mutable struct GeoArray{T<:RealOrMissing,A<:AbstractArray{T,3}} <: AbstractArray{T,3}
+mutable struct GeoArray{T<:NumberOrMissing,A<:AbstractArray{T,3}} <: AbstractArray{T,3}
     A::A
     f::CoordinateTransformations.AffineMap{StaticArrays.SMatrix{2,2,Float64,4},StaticArrays.SVector{2,Float64}}
     crs::GFT.WellKnownText{GFT.CRS}
 end
 
 """
-    GeoArray(A::AbstractArray{T,3} where T <: RealOrMissing)
+    GeoArray(A::AbstractArray{T,3} where T <: NumberOrMissing)
 
 Construct a GeoArray from any Array. A default `AffineMap` and `CRS` will be generated.
 
@@ -24,25 +24,25 @@ julia> GeoArray(rand(10,10,1))
 10x10x1 Array{Float64, 3} with AffineMap([1.0 0.0; 0.0 1.0], [0.0, 0.0]) and undefined CRS
 ```
 """
-GeoArray(A::AbstractArray{T,3} where {T<:RealOrMissing}) = GeoArray(A, geotransform_to_affine(SVector(0.0, 1.0, 0.0, 0.0, 0.0, 1.0)), "")
+GeoArray(A::AbstractArray{T,3} where {T<:NumberOrMissing}) = GeoArray(A, geotransform_to_affine(SVector(0.0, 1.0, 0.0, 0.0, 0.0, 1.0)), "")
 """
-    GeoArray(A::AbstractArray{T,3} where T <: RealOrMissing, f::AffineMap)
+    GeoArray(A::AbstractArray{T,3} where T <: NumberOrMissing, f::AffineMap)
 
 Construct a GeoArray from any Array and an `AffineMap` that specifies the coordinates. A default `CRS` will be generated.
 """
-GeoArray(A::AbstractArray{T,3} where {T<:RealOrMissing}, f::AffineMap) = GeoArray(A, f, GFT.WellKnownText(GFT.CRS(), ""))
+GeoArray(A::AbstractArray{T,3} where {T<:NumberOrMissing}, f::AffineMap) = GeoArray(A, f, GFT.WellKnownText(GFT.CRS(), ""))
 
 """
-    GeoArray(A::AbstractArray{T,3} where T <: RealOrMissing, f::AffineMap, crs::String)
+    GeoArray(A::AbstractArray{T,3} where T <: NumberOrMissing, f::AffineMap, crs::String)
 
 Construct a GeoArray from any Array and an `AffineMap` that specifies the coordinates and `crs` string in WKT format.
 """
-GeoArray(A::AbstractArray{T,3} where {T<:RealOrMissing}, f::AffineMap, crs::String) = GeoArray(A, f, GFT.WellKnownText(GFT.CRS(), crs))
+GeoArray(A::AbstractArray{T,3} where {T<:NumberOrMissing}, f::AffineMap, crs::String) = GeoArray(A, f, GFT.WellKnownText(GFT.CRS(), crs))
 
-GeoArray(A::AbstractArray{T,3} where {T<:RealOrMissing}, f::AffineMap{Matrix{Float64},Vector{Float64}}, crs::GFT.WellKnownText{GFT.CRS}) = GeoArray(A, AffineMap(SMatrix{2,2}(f.linear), SVector{2}(f.translation)), crs)
+GeoArray(A::AbstractArray{T,3} where {T<:NumberOrMissing}, f::AffineMap{Matrix{Float64},Vector{Float64}}, crs::GFT.WellKnownText{GFT.CRS}) = GeoArray(A, AffineMap(SMatrix{2,2}(f.linear), SVector{2}(f.translation)), crs)
 
 """
-    GeoArray(A::AbstractArray{T,2} where T <: RealOrMissing)
+    GeoArray(A::AbstractArray{T,2} where T <: NumberOrMissing)
 
 Construct a GeoArray from any Matrix, a third singleton dimension will be added automatically.
 
@@ -52,14 +52,14 @@ julia> GeoArray(rand(10,10))
 10x10x1 Array{Float64, 3} with AffineMap([1.0 0.0; 0.0 1.0], [0.0, 0.0]) and undefined CRS
 ```
 """
-GeoArray(A::AbstractArray{T,2} where {T<:RealOrMissing}, args...) = GeoArray(reshape(A, size(A)..., 1), args...)
+GeoArray(A::AbstractArray{T,2} where {T<:NumberOrMissing}, args...) = GeoArray(reshape(A, size(A)..., 1), args...)
 
 """
-    GeoArray(A::AbstractArray{T,3} where T <: RealOrMissing, x::AbstractRange, y::AbstractRange, args...)
+    GeoArray(A::AbstractArray{T,3} where T <: NumberOrMissing, x::AbstractRange, y::AbstractRange, args...)
 
 Construct a GeoArray any Array and it's coordinates from `AbstractRange`s for each dimension.
 """
-function GeoArray(A::AbstractArray{T,3} where {T<:RealOrMissing}, x::AbstractRange, y::AbstractRange, args...)
+function GeoArray(A::AbstractArray{T,3} where {T<:NumberOrMissing}, x::AbstractRange, y::AbstractRange, args...)
     size(A)[1:2] != (length(x), length(y)) && error("Size of `GeoArray` $(size(A)) does not match size of (x,y): $((length(x), length(y))). Note that this function takes *center coordinates*.")
     f = unitrange_to_affine(x, y)
     GeoArray(A, f, args...)

--- a/src/geoutils.jl
+++ b/src/geoutils.jl
@@ -229,7 +229,7 @@ function straighten(ga)
     end
 
     A = Array{dtype}(undef, _sizeof(ga, bbox(ga)))
-    fill!(A, missing)
+    Base.fill!(A, missing)
     gar = GeoArray(A)
 
     bbox!(gar, bbox(ga))

--- a/src/io.jl
+++ b/src/io.jl
@@ -74,13 +74,13 @@ end
 
 """
 
-    write(fn::AbstractString, ga::GeoArray; nodata::Union{Nothing,Real}=nothing, shortname::AbstractString=find_shortname(fn), options::Dict{String,String}=Dict{String,String}())
+    write(fn::AbstractString, ga::GeoArray; nodata::Union{Nothing,Number}=nothing, shortname::AbstractString=find_shortname(fn), options::Dict{String,String}=Dict{String,String}())
 
 Write a GeoArray to `fn`. `nodata` is used to set the nodata value. Any `Missing` values in the GeoArray are converted to this value, otherwise the `typemax` of the element type
 of the array is used. The shortname determines the GDAL driver, like "GTiff", when unset the filename extension is used to derive this driver. The `options` argument may be used
 to pass driver options, such as setting the compression by `Dict("compression"=>"deflate")`.
 """
-function write(fn::AbstractString, ga::GeoArray; nodata::Union{Nothing,Real}=nothing, shortname::AbstractString=find_shortname(fn), options::Dict{String,String}=Dict{String,String}())
+function write(fn::AbstractString, ga::GeoArray; nodata::Union{Nothing,Number}=nothing, shortname::AbstractString=find_shortname(fn), options::Dict{String,String}=Dict{String,String}())
     w, h, b = size(ga)
     dtype = eltype(ga)
     data = copy(ga.A)
@@ -95,6 +95,7 @@ function write(fn::AbstractString, ga::GeoArray; nodata::Union{Nothing,Real}=not
         catch
             dtype, data = cast_to_gdal(data)
         end
+        dtype <: Complex && error("Nodata is not supported with complex numbers, please use `coalesce` to replace missing values with a valid value.")
         nodata === nothing && (nodata = typemax(dtype))
         m = ismissing.(data)
         data[m] .= nodata

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -24,6 +24,25 @@ function Base.:/(a::GeoArray, b::GeoArray)
     GeoArray(a.A ./ b.A, a.f, a.crs)
 end
 
+"""
+    coalesce(ga::GeoArray, v)
+
+Replace all `missing` values in `ga` with `v` and set the `GeoArray`'s `eltype` to the non-missing type.
+
+# Examples
+```julia-repl
+julia> ga = GeoArray(collect([1 missing; 2 3]))
+2x2x1 Base.ReshapedArray{Union{Missing, Int64}, 3, Matrix{Union{Missing, Int64}}, Tuple{}} with AffineMap([1.0 0.0; 0.0 1.0], [0.0, 0.0]) and undefined CRS
+
+julia> ga2 = coalesce(ga, 0)
+2x2x1 Array{Int64, 3} with AffineMap([1.0 0.0; 0.0 1.0], [0.0, 0.0]) and undefined CRS
+julia> ga.A
+2×2×1 Array{Int64, 3}:
+[:, :, 1] =
+ 1  0
+ 2  3
+```
+"""
 function Base.coalesce(ga::GeoArray{T,A}, v) where {T,A}
     nT = nonmissingtype(T)
     cA = coalesce.(ga.A, nT(v))

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -11,8 +11,10 @@ using RecipesBase
 
     # Subsample large images
     pw, ph = get(plotattributes, :size, (600, 400))
+    ss = get(plotattributes, :scalefactor, 2)
     w, h = size(ga)
-    sw, sh = max(1, round(Int, w / pw, RoundDown)), max(1, round(Int, h / ph, RoundDown))
+    sw, sh = max(1, round(Int, w / (pw * ss), RoundDown)), max(1, round(Int, h / (ph * ss), RoundDown))
+    @debug "Using scalefactor $sw x $sh to subsample GeoArray"
     ga = sw > 1 || sh > 1 ? ga[begin:sw:end, begin:sh:end] : ga
 
     c = GeoArrays.coords(ga, Vertex())

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -9,9 +9,15 @@ using RecipesBase
 
     is_rotated(ga) && (ga = straighten(ga))
 
+    # Subsample large images
+    pw, ph = get(plotattributes, :size, (600, 400))
+    w, h = size(ga)
+    sw, sh = max(1, round(Int, w / pw, RoundDown)), max(1, round(Int, h / ph, RoundDown))
+    ga = sw > 1 || sh > 1 ? ga[begin:sw:end, begin:sh:end] : ga
+
     c = GeoArrays.coords(ga, Vertex())
-    x = map(x -> x[1], c[:, 1])
-    y = map(x -> x[2], c[end, :])
+    x = map(first, c[:, 1])
+    y = map(last, c[end, :])
     z = ga.A[:, :, band]'
 
     # Can't use x/yflip as x/y coords

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -21,6 +21,10 @@ using RecipesBase
     x = map(first, c[:, 1])
     y = map(last, c[end, :])
     z = ga.A[:, :, band]'
+    if eltype(z) <: Complex
+        @warn "Plotting real part of Complex GeoArray."
+        z = real.(z)
+    end
 
     # Can't use x/yflip as x/y coords
     # have to be sorted for Plots

--- a/test/test_io.jl
+++ b/test/test_io.jl
@@ -94,4 +94,13 @@ end
         ga = GeoArrays.read("/vsicurl/https://github.com/OSGeo/gdal/blob/master/autotest/alg/data/2by2.tif?raw=true")
         @test size(ga) == (2, 2, 1)
     end
+    @testset "Complex numbers" begin
+        for T in (Complex{Int16}, Complex{Int32}, Complex{Float32}, Complex{Float64})
+            ga = GeoArray(rand(T, 1024, 1024, 3))
+            fn = joinpath(tempdir(), "test_complex_$T.tif")
+            GeoArrays.write(fn, ga)
+            ga2 = GeoArrays.read(fn)
+            @test ga2 == ga
+        end
+    end
 end


### PR DESCRIPTION
This should limit memory usage while plotting, especially for rotated rasters.

@joshday