### PR TITLE
Add `convert`, `affine!` and broadcast methods.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.13] - 2023-01-12
+- Added convert, affine!
+- Added broadcast for GeoArray, so `ga .+ 1` isa `GeoArray`
+
 ## [0.7.12] - 2023-01-12
 - Fix interpolation, update to GeoStatsSolvers
 - Fix indexing bug in non-singleton sized GeoArrays
@@ -35,7 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed iterate specification so `sum` on a GeoArray is correct
 
-[unreleased]: https://github.com/evetion/GeoArrays.jl/compare/v0.7.9...HEAD
+[unreleased]: https://github.com/evetion/GeoArrays.jl/compare/v0.7.13...HEAD
+[0.7.13]: https://github.com/evetion/GeoArrays.jl/compare/v0.7.12...v0.7.13
 [0.7.12]: https://github.com/evetion/GeoArrays.jl/compare/v0.7.11...v0.7.12
 [0.7.11]: https://github.com/evetion/GeoArrays.jl/compare/v0.7.10...v0.7.11
 [0.7.10]: https://github.com/evetion/GeoArrays.jl/compare/v0.7.9...v0.7.10

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GeoArrays"
 uuid = "2fb1d81b-e6a0-5fc5-82e6-8e06903437ab"
 authors = ["Maarten Pronk <git@evetion.nl>"]
-version = "0.7.12"
+version = "0.7.13"
 
 [deps]
 ArchGDAL = "c9ce4bd3-c3d5-55b8-8973-c0e20141b8c3"
@@ -18,7 +18,7 @@ ArchGDAL = "0.7 - 0.9, 0.10"
 CoordinateTransformations = "0.5 - 0.6"
 GeoFormatTypes = "0.4"
 GeoInterface = "1"
-GeoStatsBase = "0.21 - 0.29"
+GeoStatsBase = "0.21 - 0.30"
 IterTools = "1"
 RecipesBase = "0.7, 0.8, 1.0"
 StaticArrays = "0.12, 1.0"

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ julia> ga = GeoArray(rand(100,200))
 julia> bbox!(ga, (min_x=2., min_y=51., max_x=5., max_y=54.))  # roughly the Netherlands
 julia> epsg!(ga, 4326)  # in WGS84
 julia> GeoArrays.write("test.tif", ga)
+# Or write it with compression and tiling
+julia> GeoArrays.write("test_compressed.tif", ga; options=Dict("TILED"=>"YES", "COMPRESS"=>"ZSTD"))
 ```
 
 ### Streaming support

--- a/src/GeoArrays.jl
+++ b/src/GeoArrays.jl
@@ -31,7 +31,7 @@ export compose!
 export bbox_overlap
 export crop
 
-export interpolate!, fill!
+export interpolate!
 
 export epsg!
 export crs!

--- a/src/geoutils.jl
+++ b/src/geoutils.jl
@@ -82,6 +82,12 @@ function bboxes(ga::GeoArray)
     cellbounds
 end
 
+function affine!(ga::GeoArray, f::AffineMap)
+    (length(f.translation) == 2 && size(f.linear) == (2, 2)) || error("AffineMap should be two dimensional.")
+    ga.f = f
+    ga
+end
+
 # Extend CoordinateTransformations
 CoordinateTransformations.compose(ga::GeoArray, t2::AffineMap) = CoordinateTransformations.compose(ga.f, t2)
 CoordinateTransformations.compose(ga::GeoArray, t2::LinearMap) = CoordinateTransformations.compose(ga.f, t2)

--- a/test/test_geoarray.jl
+++ b/test/test_geoarray.jl
@@ -90,6 +90,23 @@ end
     GeoArrays.write!("test.tif", gg)
 end
 
+@testset "Conversion" begin
+    ga = GeoArrays.GeoArray(rand(Int16, 10, 10))
+    gc = convert(GeoArrays.GeoArray{Float32}, ga)
+    @test gc isa GeoArray
+    @test eltype(gc) == Float32
+    @test all(ga .== gc)
+end
+
+@testset "Broadcast" begin
+    ga = GeoArrays.GeoArray(rand(Int16, 10, 10))
+    gc = clamp.(ga, 0, 1)
+    @test gc isa GeoArray
+    @test sum(gc) < length(gc)
+    gd = gc .+ 1
+    @test sum(gd) > length(gc)
+end
+
 @testset "Indexing" begin
     ga = GeoArray(rand(10, 10))
     @inferred ga[Float32(1.0), Float32(2.0)]

--- a/test/test_io.jl
+++ b/test/test_io.jl
@@ -75,15 +75,15 @@ end
     end
     @testset "COG" begin
         ga = GeoArray(Array{Union{Missing,Int32}}(rand(1:10, 2048, 2048, 3)))
-        fn = GeoArrays.write(joinpath(testdatadir, "test_cog.tif"), ga; nodata=-1, shortname="COG", options=Dict("COMPRESSION" => "ZSTD"))
+        fn = GeoArrays.write(joinpath(testdatadir, "test_cog.tif"), ga; nodata=-1, shortname="COG", options=Dict("compress" => "ZSTD"))
         GeoArrays.read(fn)
         ga = GeoArray(Array{Union{Missing,Float32}}(rand(1:10, 2048, 2048, 3)))
-        fn = GeoArrays.write(joinpath(testdatadir, "test_cogf.tif"), ga; nodata=Inf, shortname="COG", options=Dict("COMPRESSION" => "ZSTD"))
+        fn = GeoArrays.write(joinpath(testdatadir, "test_cogf.tif"), ga; nodata=Inf, shortname="COG", options=Dict("compress" => "ZSTD"))
         GeoArrays.read(fn)
     end
     @testset "Kwargs" begin
         ga = GeoArray(rand(100, 200, 3))
-        fn = GeoArrays.write(joinpath(tempdir(), "test.tif"), ga; shortname="COG", nodata=1.0, options=Dict("compression" => "deflate"))
+        fn = GeoArrays.write(joinpath(tempdir(), "test.tif"), ga; shortname="COG", nodata=1.0, options=Dict("compress" => "deflate"))
         GeoArrays.read(fn)
     end
     @testset "NetCDF" begin


### PR DESCRIPTION
Fixes #120 #119.

This enables `affine!`. For conversion you can do `convert(GeoArray{T}, ga)`, but only for types where this works naturally (from int to float), the other way around would induce `InexactError`. For those cases, I've extended broadcoast, so one can also do `round.(Int, ga)`.

Still need some tests.