### PR TITLE
Normalize driver options COMPRESS keyword

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -94,7 +94,7 @@ end
 
 Write a GeoArray to `fn`. `nodata` is used to set the nodata value. Any `Missing` values in the GeoArray are converted to this value, otherwise the `typemax` of the element type
 of the array is used. The shortname determines the GDAL driver, like "GTiff", when unset the filename extension is used to derive this driver. The `options` argument may be used
-to pass driver options, such as setting the compression by `Dict("compression"=>"deflate")`. The `bandnames` keyword argument can be set to a vector or tuple of strings to set 
+to pass driver options, such as setting the compression by `Dict("compress"=>"deflate")`. The `bandnames` keyword argument can be set to a vector or tuple of strings to set 
 the band descriptions. It should have the same length as the number of bands.
 """
 function write(fn::AbstractString, ga::GeoArray; nodata::Union{Nothing,Number}=nothing, shortname::AbstractString=find_shortname(fn), options::Dict{String,String}=Dict{String,String}(), bandnames=nothing)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -83,7 +83,7 @@ end
 function stringlist(dict::Dict{String})
     sv = Vector{String}()
     for (k, v) in pairs(dict)
-        push!(sv, uppercase(string(k)) * "=" * string(v))
+        push!(sv, replace(uppercase(string(k)), "COMPRESSION"=>"COMPRESS", "COMPRESSED"=>"COMPRESS") * "=" * string(v))
     end
     return sv
 end


### PR DESCRIPTION
The `write` function docstring was incorrectly suggesting `compression` as a driver options keyword, but that does not work and has been corrected to `compress`.

The `stringlist` util function has also been updated to be less strict for the `COMPRESS` keyword by normalizing `COMPRESSION` to `COMPRESS` and `COMPRESSED` to `COMPRESS`.