### PR TITLE
Warn when passing unknown driver creation options

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -94,7 +94,7 @@ end
 
 Write a GeoArray to `fn`. `nodata` is used to set the nodata value. Any `Missing` values in the GeoArray are converted to this value, otherwise the `typemax` of the element type
 of the array is used. The shortname determines the GDAL driver, like "GTiff", when unset the filename extension is used to derive this driver. The `options` argument may be used
-to pass driver options, such as setting the compression by `Dict("compression"=>"deflate")`. The `bandnames` keyword argument can be set to a vector or tuple of strings to set 
+to pass driver options, such as setting the compression by `Dict("compress"=>"deflate")`. The `bandnames` keyword argument can be set to a vector or tuple of strings to set 
 the band descriptions. It should have the same length as the number of bands.
 """
 function write(fn::AbstractString, ga::GeoArray; nodata::Union{Nothing,Number}=nothing, shortname::AbstractString=find_shortname(fn), options::Dict{String,String}=Dict{String,String}(), bandnames=nothing)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -80,10 +80,50 @@ function setmetadata(ds::ArchGDAL.AbstractDataset, d::Dict{String})
     end
 end
 
-function stringlist(dict::Dict{String})
+const gtiffcreationoptions = [
+    "TFW",
+    "RPB",
+    "RPCTXT",
+    "INTERLEAVE",
+    "TILED",
+    "BLOCKXSIZE",
+    "BLOCKYSIZE",
+    "NBITS",
+    "COMPRESS",
+    "NUM_THREADS",
+    "PREDICTOR",
+    "DISCARD_LSB",
+    "SPARSE_OK",
+    "JPEG_QUALITY",
+    "JPEGTABLESMODE",
+    "ZLEVEL",
+    "ZSTD_LEVEL",
+    "MAX_Z_ERROR",
+    "MAX_Z_ERROR_OVERVIEW",
+    "WEBP_LEVEL",
+    "WEBP_LOSSLESS",
+    "JXL_LOSSLESS",
+    "JXL_EFFORT",
+    "JXL_DISTANCE",
+    "JXL_ALPHA_DISTANCE",
+    "PHOTOMETRIC",
+    "ALPHA",
+    "PROFILE",
+    "BIGTIFF",
+    "PIXELTYPE",
+    "COPY_SRC_OVERVIEWS",
+    "STREAMABLE_OUTPUT",
+    "GEOTIFF_KEYS_FLAVOR",
+    "GEOTIFF_VERSION",
+    "COLOR_TABLE_MULTIPLIER"
+]
+
+function stringlist(dict::Dict{String}; validate = true, validatelist = gtiffcreationoptions)
     sv = Vector{String}()
     for (k, v) in pairs(dict)
-        push!(sv, uppercase(string(k)) * "=" * string(v))
+        nk = uppercase(string(k))
+        validate && !(nk in validatelist) && @warn "Unrecognized key $nk. Should be one of $validatelist"
+        push!(sv, nk * "=" * string(v))
     end
     return sv
 end


### PR DESCRIPTION
The `write` function docstring was incorrectly suggesting `compression` as a driver creation options keyword, but that does not work and has been corrected to `compress`.

The `stringlist` util function has also been updated to check the provided dict keywords against a list of supported driver creation options keywords, and warn when the provided keyword is unrecognized. No checking or warning is performed on the values passed together with the keywords. I could not find a list of supported driver creation options in GDAL.jl or ArchGDAL.jl, so I hardcoded a list based on the [Creation Options in the GDAL GTiff documentation](https://gdal.org/en/latest/drivers/raster/gtiff.html#creation-options).

I see that the `warpstringlist` function calls `stringlist`. Does it support the same keywords, or is it for a different purpose?

Also, should the `stringlist` and `warpstringlist` input argument `dict::Dict{String}` be changed to `dict::Dict{String,String}`?