### PR TITLE
Implement GeoInterface crstrait.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,8 +1,7 @@
 name = "GeoArrays"
 uuid = "2fb1d81b-e6a0-5fc5-82e6-8e06903437ab"
 authors = ["Maarten Pronk <git@evetion.nl>"]
-version = "0.9.3"
-
+version = "0.9.4"
 
 [deps]
 ArchGDAL = "c9ce4bd3-c3d5-55b8-8973-c0e20141b8c3"
@@ -17,9 +16,9 @@ RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [weakdeps]
-Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 GeoStatsModels = "ad987403-13c5-47b5-afee-0a48f6ac4f12"
 GeoStatsTransforms = "725d9659-360f-4996-9c94-5f19c7e4a8a6"
+Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 
 [extensions]
 GeoArraysMakieExt = "Makie"
@@ -35,7 +34,7 @@ GeoInterface = "1"
 GeoStatsModels = "0.6"
 GeoStatsTransforms = "0.9"
 IterTools = "1"
-Makie = "0.21"
+Makie = "0.21, 0.22"
 PrecompileTools = "1"
 RecipesBase = "0.7, 0.8, 1.0"
 StaticArrays = "0.12, 1.0"

--- a/src/geointerface.jl
+++ b/src/geointerface.jl
@@ -1,2 +1,14 @@
 GI.extent(ga::GeoArray) = bbox(ga)
 GI.crs(ga::GeoArray) = isempty(GFT.val(crs(ga))) ? nothing : crs(ga)
+GI.israster(::Type{GeoArray}) = true
+GI.crstrait(ga::GeoArray) = _crstrait(GI.crs(ga))
+
+_crstrait(::Nothing) = GI.UnknownTrait()
+function _crstrait(crs)
+    acrs = ArchGDAL.importCRS(crs)
+    Bool(ArchGDAL.GDAL.osrisgeographic(acrs.ptr)) && return GI.GeographicTrait()
+    Bool(ArchGDAL.GDAL.osrisprojected(acrs.ptr)) && return GI.ProjectedTrait()
+    @error "Unknown CRS type, please report this issue for the given crs/file"
+    return GI.UnknownTrait()
+end
+

--- a/test/test_geoutils.jl
+++ b/test/test_geoutils.jl
@@ -114,6 +114,7 @@ const tbbox = GeoArrays._convert(Extent, (min_x=440720.0, min_y=3.74532e6, max_x
         @test !isempty(GFT.val(GI.crs(ga)))
         @test GI.extent(ga) isa Extents.Extent
         @test GI.extent(ga) == Extents.Extent(X=(440720.0, 446720.0), Y=(3.74532e6, 3.75132e6))
+        @test GI.crstrait(ga) isa GI.ProjectedTrait
     end
 
     @testset "Compose" begin


### PR DESCRIPTION
@asinghvi17 @rafaqz AFAIK, this is the easiest way to distuingish between Projected/Geographic, altough it needs GDAL. 

There are even methods like GDAL.osrgetsemimajor and GDAL.osrgetsemiminor to get your manifolds more correct.

In PROJ you have the same is_geographic and is_projected (altough made by me, so they might need more complex logic, like splitting a compound (3D crs) into horizontal/vertical first, and then calling these methods on the horizontal one).